### PR TITLE
Fix astropy deprecation

### DIFF
--- a/pypher/pypher.py
+++ b/pypher/pypher.py
@@ -33,7 +33,7 @@ from scipy.ndimage import rotate, zoom
 from pypher import fitsutils as fits
 from pypher.parser import ThrowingArgumentParser, ArgumentParserError
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 
 def parse_args():

--- a/pypher/tests/conftest.py
+++ b/pypher/tests/conftest.py
@@ -22,7 +22,7 @@ def create_mock_fits():
     # Single extension FITS
     img = fits.ImageHDU(data=x)
     singlehdu = fits.HDUList([prihdu, img])
-    singlehdu.writeto('image.fits', clobber=True)
+    singlehdu.writeto('image.fits', overwrite=True)
 
 
 @pytest.fixture(scope="module")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.7.2
 scipy>=0.9.0
-astropy>=0.4
+astropy>=2.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         'numpy>=1.7.2',
         'scipy>=0.9',
-        'astropy>=0.4'
+        'astropy>=2.0'
     ],
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
astropy has deprecated the `clobber` keyword from the fits `writeto` method in favor of `overwrite`
cf. https://github.com/astropy/astropy/pull/5171

Since version 5.1 (end of May 2022), it was finally removed. 