### PR TITLE
Fix numpy 2.0 compatibility.

### DIFF
--- a/pypher/pypher.py
+++ b/pypher/pypher.py
@@ -190,7 +190,7 @@ def trim(image, shape):
     shape = np.asarray(shape, dtype=int)
     imshape = np.asarray(image.shape, dtype=int)
 
-    if np.alltrue(imshape == shape):
+    if np.all(imshape == shape):
         return image
 
     if np.any(shape <= 0):
@@ -236,7 +236,7 @@ def zero_pad(image, shape, position='corner'):
     shape = np.asarray(shape, dtype=int)
     imshape = np.asarray(image.shape, dtype=int)
 
-    if np.alltrue(imshape == shape):
+    if np.all(imshape == shape):
         return image
 
     if np.any(shape <= 0):


### PR DESCRIPTION
`np.alltrue()` has been deprecated since numpy 1.25, and has been removed in numpy 2.0.

This replaces both occurrences with `np.all()` to maintain compatibility (ref. [migration guide](https://numpy.org/doc/2.0/numpy_2_0_migration_guide.html)).

